### PR TITLE
fix: typo

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -198,7 +198,7 @@ function parseThriftFile(filePath) {
  */
 function run(params) {
   if (params.dirOrFile === 'file') {
-    parseThriftFile(params.thirft);
+    parseThriftFile(params.thrift);
   } else if (params.dirOrFile === 'dir') {
     getFileFromDir(params.thrift, params.inputExt).forEach(function(filePath) {
       parseThriftFile(filePath);


### PR DESCRIPTION
解决拼写错误导致命令行调用失败问题。